### PR TITLE
Change the recipe to point to 3.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pymbar" %}
-{% set version = "3.0.2" %}
-{% set sha256 = "6a161ea32addddc26384b2e32086b28996bd1e7b0d759472452e86a6c4cf90dc" %}
+{% set version = "3.0.3" %}
+{% set sha256 = "5e59bb9f3789ae723e85d4483d7d204e39425551f30df8cefc13c6e607af6398" %}
 
 package:
   name: {{ name  }}


### PR DESCRIPTION
3.0.3 fixes the PyPi release of PyMBAR, but should do nothing to the conda-forge version since each Python version is compiled separately on conda-forge. However, I want the versions to match on conda-forge and PyPi so there is no confusion as "which is the latest which version should I get?"