### PR TITLE
Jax as build varient

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+accelerator:
+  - jax
+  - core


### PR DESCRIPTION
An example of how to include JAX as default build varient.